### PR TITLE
feat: structured error taxonomy (#2) + CoreEvent JSON Schema (#1)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,9 @@ jobs:
         run: |
           mkdir -p _site
           cp openapi.json _site/openapi.json
+          cp corevents.schema.json _site/corevents.schema.json
           cp docs/index.html _site/index.html
+          cp docs/errors.md _site/errors.md
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,25 @@
+name: Validate specs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install deps
+        run: npm install --no-audit --no-fund
+
+      - name: Lint OpenAPI document
+        run: npm run lint:openapi
+
+      - name: Validate fixtures against schemas
+        run: npm run test:schemas

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+_site/

--- a/README.md
+++ b/README.md
@@ -1,17 +1,35 @@
 # tmai-api-spec
 
-Public API contracts for [tmai](https://github.com/trust-delta/tmai) — the UI contract between `tmai-core` and its UI clients (`tmai-ratatui`, `tmai-react`, and any third-party UI).
+Public API contracts for **tmai**, published as the stable interface between its private core and its public UI clients.
+
+```
+                                    (public)
+            ┌──────────────────────── tmai-api-spec ─────────────────────────┐
+            │  openapi.json · corevents.schema.json · docs/errors.md · docs/ │
+            └────▲───────────────────────────────────────────────────▲───────┘
+                 │ publishes the public contract                     │ consumes
+                 │                                                   │
+          ┌──────┴──────┐                              ┌─────────────┴──────────┐
+          │  tmai-core  │                              │       tmai-react       │
+          │  (private)  │ ◀─── HTTP / SSE / MCP ──────▶│ (public WebUI client)  │
+          └─────────────┘                              └────────────────────────┘
+```
+
+- **[`tmai-core`](https://github.com/trust-delta/tmai-core)** — private, language-agnostic server that owns the live agent / dispatch state and implements the API.
+- **`tmai-api-spec`** (this repo, public) — the only authoritative description of what `tmai-core` exposes. All downstream clients build against this.
+- **[`tmai-react`](https://github.com/trust-delta/tmai-react)** — public React WebUI; a reference consumer of the spec. Third-party UIs (TUIs, mobile, other automations) consume the same spec.
 
 ## What lives here
 
-| File | Purpose |
-|------|---------|
-| `openapi.json` | OpenAPI 3.1 document describing the HTTP REST API served by `tmai-core` |
-| `docs/index.html` | Redoc-based documentation viewer (published via GitHub Pages) |
+| File                           | Purpose |
+|--------------------------------|---------|
+| `openapi.json`                 | OpenAPI 3.1 document describing the HTTP REST API served by `tmai-core`, including the `TmaiError` / `ErrorCode` / `RetryHint` taxonomy reused across every surface |
+| `corevents.schema.json`        | JSON Schema (2020-12) for every `CoreEvent` variant emitted on the `/api/events` SSE stream |
+| `docs/errors.md`               | Human-readable error taxonomy — per-code semantics, typical `context`, typical `retry_hint` |
+| `docs/index.html`              | Redoc-based documentation viewer with links to the JSON Schema and error taxonomy (published via GitHub Pages) |
 
 Future additions (planned):
 
-- `corevents.schema.json` — JSON Schema for SSE `CoreEvent` variants
 - `mcp-tools.json` — snapshot of MCP `tools/list` output from `tmai-core`
 - Versioned directories (`v0.1.0/`, `v0.2.0/`, ...) for historical specs
 
@@ -51,7 +69,7 @@ Hosted at https://trust-delta.github.io/tmai-api-spec/ (Redoc-rendered).
 
 ## Status
 
-**v0.0.1 — bootstrap.** Contains the initial PoC endpoint (`GET /api/task-meta`) migrated from `tmai-core` issue #446. The remaining ~79 endpoints will be added incrementally; breaking changes are permitted at any time during v0.x.
+**v0.1.0 — contract-layer bootstrap.** The initial PoC endpoint (`GET /api/task-meta`, migrated from `tmai-core` issue #446) now sits alongside the full `TmaiError` / `ErrorCode` / `RetryHint` taxonomy (issue #2) and `corevents.schema.json` covering every `CoreEvent` variant including the contract-layer additions (issue #1). The remaining ~79 REST endpoints will be added incrementally; breaking changes are permitted at any time during v0.x.
 
 ## License
 

--- a/corevents.schema.json
+++ b/corevents.schema.json
@@ -1,0 +1,678 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trust-delta.github.io/tmai-api-spec/corevents.schema.json",
+  "title": "CoreEvent",
+  "description": "Push-based state-change events emitted by tmai-core and streamed to UI clients over SSE at `/api/events` (and fanned out to MCP and audit consumers). Every variant is discriminated by the `type` field (internally tagged) and carries event-specific fields at the top level.\n\n## Forward-compatibility rules\n\nUI clients MUST ignore unknown `type` values — new variants will be added as non-breaking changes. New optional fields SHOULD be tolerated silently. Required field changes, field-type changes, or variant removals trigger a major version bump of this spec.\n\n## Taxonomy cross-reference\n\nContract-layer events (`DispatchRejected`, `ContractViolation`) embed a `TmaiError` / `ErrorCode` whose shape is defined in `openapi.json` → `components.schemas.TmaiError`. The shapes are kept in sync — see `docs/errors.md` for authoritative documentation.",
+  "oneOf": [
+    { "$ref": "#/$defs/AgentsUpdated" },
+    { "$ref": "#/$defs/AgentStatusChanged" },
+    { "$ref": "#/$defs/AgentAppeared" },
+    { "$ref": "#/$defs/AgentDisappeared" },
+    { "$ref": "#/$defs/TeamsUpdated" },
+    { "$ref": "#/$defs/TeammateIdle" },
+    { "$ref": "#/$defs/TaskCreated" },
+    { "$ref": "#/$defs/TaskCompleted" },
+    { "$ref": "#/$defs/ConfigChanged" },
+    { "$ref": "#/$defs/WorktreeCreated" },
+    { "$ref": "#/$defs/WorktreeRemoved" },
+    { "$ref": "#/$defs/InstructionsLoaded" },
+    { "$ref": "#/$defs/AgentStopped" },
+    { "$ref": "#/$defs/ContextCompacting" },
+    { "$ref": "#/$defs/WorktreeSetupCompleted" },
+    { "$ref": "#/$defs/WorktreeSetupFailed" },
+    { "$ref": "#/$defs/PromptReady" },
+    { "$ref": "#/$defs/UsageUpdated" },
+    { "$ref": "#/$defs/ToolCallDeferred" },
+    { "$ref": "#/$defs/RebaseSucceeded" },
+    { "$ref": "#/$defs/RebaseConflict" },
+    { "$ref": "#/$defs/ToolCallResolved" },
+    { "$ref": "#/$defs/PrCreated" },
+    { "$ref": "#/$defs/PrCiPassed" },
+    { "$ref": "#/$defs/PrCiFailed" },
+    { "$ref": "#/$defs/PrReviewFeedback" },
+    { "$ref": "#/$defs/PrClosed" },
+    { "$ref": "#/$defs/GitStateChanged" },
+    { "$ref": "#/$defs/GuardrailExceeded" },
+    { "$ref": "#/$defs/AgentTargetChanged" },
+    { "$ref": "#/$defs/ActionPerformed" },
+    { "$ref": "#/$defs/DispatchRejected" },
+    { "$ref": "#/$defs/VendorAvailabilityChanged" },
+    { "$ref": "#/$defs/CapacityChanged" },
+    { "$ref": "#/$defs/ContractViolation" },
+    { "$ref": "#/$defs/DispatchBypassUsed" },
+    { "$ref": "#/$defs/BundleStatusChanged" }
+  ],
+  "$defs": {
+    "ActionOrigin": {
+      "description": "Who initiated an action — attached to events that audit-matter or need per-origin handling.",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "Human",
+          "required": ["kind", "interface"],
+          "properties": {
+            "kind": { "const": "Human" },
+            "interface": {
+              "type": "string",
+              "description": "Which UI: \"webui\", \"tui\", \"mobile\", \"cli\", etc."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "title": "Agent",
+          "required": ["kind", "id", "is_orchestrator"],
+          "properties": {
+            "kind": { "const": "Agent" },
+            "id": { "type": "string", "description": "Agent target id (e.g. \"main:0.0\")." },
+            "is_orchestrator": { "type": "boolean" }
+          }
+        },
+        {
+          "type": "object",
+          "title": "System",
+          "required": ["kind", "subsystem"],
+          "properties": {
+            "kind": { "const": "System" },
+            "subsystem": {
+              "type": "string",
+              "description": "Subsystem name (e.g. \"auto_cleanup\", \"pr_monitor\")."
+            }
+          }
+        }
+      ]
+    },
+    "DetectionSource": {
+      "description": "How a state transition was detected.",
+      "type": "string",
+      "enum": ["HttpHook", "IpcSocket", "WebSocket", "CapturePane"]
+    },
+    "GuardrailKind": {
+      "description": "Type of guardrail that was exceeded.",
+      "type": "string",
+      "enum": ["ci_retries", "review_loops", "consecutive_failures"]
+    },
+    "WorktreeInfo": {
+      "type": "object",
+      "description": "Details of a git worktree. All fields optional — some code paths only know a subset.",
+      "properties": {
+        "name": { "type": ["string", "null"] },
+        "path": { "type": ["string", "null"] },
+        "branch": { "type": ["string", "null"] },
+        "original_repo": { "type": ["string", "null"] }
+      }
+    },
+    "BundleId": {
+      "type": "string",
+      "description": "Opaque identifier for a dispatch bundle (a logical grouping of sub-dispatches). Serialized transparently."
+    },
+    "BundleStatus": {
+      "type": "string",
+      "description": "Rollup status of a dispatch bundle.",
+      "enum": ["pending", "running", "partially_completed", "completed", "failed", "cancelled"]
+    },
+    "DispatchIntentSummary": {
+      "type": "object",
+      "description": "Redacted summary of a dispatch intent. Full prompts and credentials MUST NEVER appear here; auditors correlate via `prompt_hash`.",
+      "required": ["project_path", "role"],
+      "properties": {
+        "project_path": { "type": "string" },
+        "role": { "type": "string" },
+        "bundle_id": { "$ref": "#/$defs/BundleId" },
+        "prompt_hash": {
+          "type": "string",
+          "description": "Hex digest (implementation-chosen hash) of the dispatched prompt."
+        },
+        "issue_number": { "type": "integer", "format": "int64", "minimum": 0 },
+        "pr_number": { "type": "integer", "format": "int64", "minimum": 0 }
+      }
+    },
+    "VendorAvailabilityState": {
+      "description": "Rollup availability state for a vendor.",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "Available",
+          "required": ["state"],
+          "properties": { "state": { "const": "available" } }
+        },
+        {
+          "type": "object",
+          "title": "RateLimited",
+          "required": ["state"],
+          "properties": {
+            "state": { "const": "rate_limited" },
+            "resume_at": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Wall-clock time when dispatches may resume. Omitted when the vendor did not advertise a reset."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "title": "Unavailable",
+          "required": ["state", "reason"],
+          "properties": {
+            "state": { "const": "unavailable" },
+            "reason": { "type": "string", "description": "Free-text reason (never includes secrets)." }
+          }
+        }
+      ]
+    },
+    "CapacityCauseSummary": {
+      "description": "What triggered a capacity change.",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "AgentSpawned",
+          "required": ["kind", "target"],
+          "properties": {
+            "kind": { "const": "agent_spawned" },
+            "target": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "title": "AgentTerminated",
+          "required": ["kind", "target"],
+          "properties": {
+            "kind": { "const": "agent_terminated" },
+            "target": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "title": "LimitChanged",
+          "required": ["kind"],
+          "properties": { "kind": { "const": "limit_changed" } }
+        },
+        {
+          "type": "object",
+          "title": "Reconciled",
+          "required": ["kind"],
+          "properties": { "kind": { "const": "reconciled" } }
+        }
+      ]
+    },
+    "ErrorCode": {
+      "type": "string",
+      "description": "Mirror of `openapi.json` → `components.schemas.ErrorCode`. Kept in sync with the taxonomy documented in `docs/errors.md`.",
+      "enum": [
+        "CapacityExceeded",
+        "VendorUnavailable",
+        "QueueFull",
+        "AgentNotFound",
+        "AgentInTerminalState",
+        "WorktreeConflict",
+        "PermissionDenied",
+        "TokenInvalid",
+        "InvalidArgument",
+        "SchemaMismatch",
+        "VendorError",
+        "TmuxError",
+        "IpcError",
+        "Internal"
+      ]
+    },
+    "RetryHint": {
+      "description": "Mirror of `openapi.json` → `components.schemas.RetryHint`.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "resume_at"],
+          "properties": {
+            "kind": { "const": "retry_after" },
+            "resume_at": { "type": "string", "format": "date-time" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "ms"],
+          "properties": {
+            "kind": { "const": "backoff_ms" },
+            "ms": { "type": "integer", "format": "int64", "minimum": 0 }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind"],
+          "properties": { "kind": { "const": "not_retryable" } }
+        }
+      ]
+    },
+    "TmaiError": {
+      "type": "object",
+      "description": "Mirror of `openapi.json` → `components.schemas.TmaiError`.",
+      "required": ["code", "message"],
+      "properties": {
+        "code": { "$ref": "#/$defs/ErrorCode" },
+        "message": { "type": "string" },
+        "retry_hint": { "$ref": "#/$defs/RetryHint" },
+        "context": { "type": "object", "additionalProperties": true },
+        "trace_id": { "type": "string" }
+      }
+    },
+    "AgentsUpdated": {
+      "type": "object",
+      "description": "The full agent list was refreshed after a poll cycle.",
+      "required": ["type"],
+      "properties": { "type": { "const": "AgentsUpdated" } }
+    },
+    "AgentStatusChanged": {
+      "type": "object",
+      "description": "A single agent transitioned to a new status.",
+      "required": ["type", "target", "old_status", "new_status"],
+      "properties": {
+        "type": { "const": "AgentStatusChanged" },
+        "target": { "type": "string" },
+        "old_status": { "type": "string" },
+        "new_status": { "type": "string" }
+      }
+    },
+    "AgentAppeared": {
+      "type": "object",
+      "description": "A new agent was detected.",
+      "required": ["type", "target"],
+      "properties": {
+        "type": { "const": "AgentAppeared" },
+        "target": { "type": "string" }
+      }
+    },
+    "AgentDisappeared": {
+      "type": "object",
+      "description": "An agent is no longer visible.",
+      "required": ["type", "target"],
+      "properties": {
+        "type": { "const": "AgentDisappeared" },
+        "target": { "type": "string" }
+      }
+    },
+    "TeamsUpdated": {
+      "type": "object",
+      "description": "Team data was refreshed.",
+      "required": ["type"],
+      "properties": { "type": { "const": "TeamsUpdated" } }
+    },
+    "TeammateIdle": {
+      "type": "object",
+      "description": "A team member became idle (waiting for next task).",
+      "required": ["type", "target", "team_name", "member_name"],
+      "properties": {
+        "type": { "const": "TeammateIdle" },
+        "target": { "type": "string" },
+        "team_name": { "type": "string" },
+        "member_name": { "type": "string" }
+      }
+    },
+    "TaskCreated": {
+      "type": "object",
+      "description": "A new task was created.",
+      "required": ["type", "team_name", "task_id", "task_subject"],
+      "properties": {
+        "type": { "const": "TaskCreated" },
+        "team_name": { "type": "string" },
+        "task_id": { "type": "string" },
+        "task_subject": { "type": "string" }
+      }
+    },
+    "TaskCompleted": {
+      "type": "object",
+      "description": "A task was completed.",
+      "required": ["type", "team_name", "task_id", "task_subject"],
+      "properties": {
+        "type": { "const": "TaskCompleted" },
+        "team_name": { "type": "string" },
+        "task_id": { "type": "string" },
+        "task_subject": { "type": "string" }
+      }
+    },
+    "ConfigChanged": {
+      "type": "object",
+      "description": "A Claude Code configuration file was changed.",
+      "required": ["type", "target", "source", "file_path"],
+      "properties": {
+        "type": { "const": "ConfigChanged" },
+        "target": { "type": "string" },
+        "source": {
+          "type": "string",
+          "description": "Config source (e.g. \"user_settings\", \"project_settings\")."
+        },
+        "file_path": { "type": "string" }
+      }
+    },
+    "WorktreeCreated": {
+      "type": "object",
+      "description": "A git worktree was created.",
+      "required": ["type", "target", "worktree"],
+      "properties": {
+        "type": { "const": "WorktreeCreated" },
+        "target": { "type": "string" },
+        "worktree": {
+          "anyOf": [{ "$ref": "#/$defs/WorktreeInfo" }, { "type": "null" }]
+        }
+      }
+    },
+    "WorktreeRemoved": {
+      "type": "object",
+      "description": "A git worktree was removed.",
+      "required": ["type", "target", "worktree"],
+      "properties": {
+        "type": { "const": "WorktreeRemoved" },
+        "target": { "type": "string" },
+        "worktree": {
+          "anyOf": [{ "$ref": "#/$defs/WorktreeInfo" }, { "type": "null" }]
+        }
+      }
+    },
+    "InstructionsLoaded": {
+      "type": "object",
+      "description": "`CLAUDE.md` or `.claude/rules/*.md` files were loaded into context (Claude Code v2.1.69+).",
+      "required": ["type", "target"],
+      "properties": {
+        "type": { "const": "InstructionsLoaded" },
+        "target": { "type": "string" }
+      }
+    },
+    "AgentStopped": {
+      "type": "object",
+      "description": "An agent stopped (completed or paused), emitted by the hook handler.",
+      "required": ["type", "target", "cwd", "last_assistant_message"],
+      "properties": {
+        "type": { "const": "AgentStopped" },
+        "target": { "type": "string" },
+        "cwd": { "type": "string" },
+        "last_assistant_message": { "type": ["string", "null"] }
+      }
+    },
+    "ContextCompacting": {
+      "type": "object",
+      "description": "Context compaction started (PreCompact hook event).",
+      "required": ["type", "target", "compaction_count"],
+      "properties": {
+        "type": { "const": "ContextCompacting" },
+        "target": { "type": "string" },
+        "compaction_count": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 0
+        }
+      }
+    },
+    "WorktreeSetupCompleted": {
+      "type": "object",
+      "description": "Worktree setup commands completed successfully.",
+      "required": ["type", "worktree_path", "branch"],
+      "properties": {
+        "type": { "const": "WorktreeSetupCompleted" },
+        "worktree_path": { "type": "string" },
+        "branch": { "type": "string" }
+      }
+    },
+    "WorktreeSetupFailed": {
+      "type": "object",
+      "description": "Worktree setup commands failed.",
+      "required": ["type", "worktree_path", "branch", "error"],
+      "properties": {
+        "type": { "const": "WorktreeSetupFailed" },
+        "worktree_path": { "type": "string" },
+        "branch": { "type": "string" },
+        "error": { "type": "string" }
+      }
+    },
+    "PromptReady": {
+      "type": "object",
+      "description": "A queued prompt is ready to be delivered (agent transitioned to Idle).",
+      "required": ["type", "target", "prompt"],
+      "properties": {
+        "type": { "const": "PromptReady" },
+        "target": { "type": "string" },
+        "prompt": { "type": "string" }
+      }
+    },
+    "UsageUpdated": {
+      "type": "object",
+      "description": "Usage data was updated after a fetch cycle.",
+      "required": ["type"],
+      "properties": { "type": { "const": "UsageUpdated" } }
+    },
+    "ToolCallDeferred": {
+      "type": "object",
+      "description": "A tool call was deferred for external resolution.",
+      "required": ["type", "defer_id", "target", "tool_name"],
+      "properties": {
+        "type": { "const": "ToolCallDeferred" },
+        "defer_id": { "type": "integer", "format": "int64", "minimum": 0 },
+        "target": { "type": "string" },
+        "tool_name": { "type": "string" }
+      }
+    },
+    "RebaseSucceeded": {
+      "type": "object",
+      "description": "A worktree branch was successfully rebased onto the default branch.",
+      "required": ["type", "branch", "worktree_path"],
+      "properties": {
+        "type": { "const": "RebaseSucceeded" },
+        "branch": { "type": "string" },
+        "worktree_path": { "type": "string" }
+      }
+    },
+    "RebaseConflict": {
+      "type": "object",
+      "description": "A worktree branch rebase failed due to conflicts.",
+      "required": ["type", "branch", "worktree_path", "error"],
+      "properties": {
+        "type": { "const": "RebaseConflict" },
+        "branch": { "type": "string" },
+        "worktree_path": { "type": "string" },
+        "error": { "type": "string" }
+      }
+    },
+    "ToolCallResolved": {
+      "type": "object",
+      "description": "A deferred tool call was resolved (approved/denied).",
+      "required": ["type", "defer_id", "target", "decision", "resolved_by"],
+      "properties": {
+        "type": { "const": "ToolCallResolved" },
+        "defer_id": { "type": "integer", "format": "int64", "minimum": 0 },
+        "target": { "type": "string" },
+        "decision": {
+          "type": "string",
+          "description": "Resolution: \"allow\" or \"deny\".",
+          "enum": ["allow", "deny"]
+        },
+        "resolved_by": {
+          "type": "string",
+          "description": "Who resolved it (e.g. \"human\", \"ai:haiku\", \"timeout\")."
+        }
+      }
+    },
+    "PrCreated": {
+      "type": "object",
+      "description": "A new PR was detected by the PR monitor.",
+      "required": ["type", "pr_number", "title", "branch"],
+      "properties": {
+        "type": { "const": "PrCreated" },
+        "pr_number": { "type": "integer", "format": "int64", "minimum": 0 },
+        "title": { "type": "string" },
+        "branch": { "type": "string" }
+      }
+    },
+    "PrCiPassed": {
+      "type": "object",
+      "description": "CI checks passed for a PR.",
+      "required": ["type", "pr_number", "title", "checks_summary"],
+      "properties": {
+        "type": { "const": "PrCiPassed" },
+        "pr_number": { "type": "integer", "format": "int64", "minimum": 0 },
+        "title": { "type": "string" },
+        "checks_summary": { "type": "string" }
+      }
+    },
+    "PrCiFailed": {
+      "type": "object",
+      "description": "CI checks failed for a PR.",
+      "required": ["type", "pr_number", "title", "failed_details"],
+      "properties": {
+        "type": { "const": "PrCiFailed" },
+        "pr_number": { "type": "integer", "format": "int64", "minimum": 0 },
+        "title": { "type": "string" },
+        "failed_details": { "type": "string" }
+      }
+    },
+    "PrReviewFeedback": {
+      "type": "object",
+      "description": "A PR received review feedback (changes requested). `review_count` is a monotonic counter — use `(pr_number, review_count)` as the dedup key.",
+      "required": ["type", "pr_number", "title", "comments_summary", "review_count"],
+      "properties": {
+        "type": { "const": "PrReviewFeedback" },
+        "pr_number": { "type": "integer", "format": "int64", "minimum": 0 },
+        "title": { "type": "string" },
+        "comments_summary": { "type": "string" },
+        "review_count": { "type": "integer", "format": "int64", "minimum": 0 }
+      }
+    },
+    "PrClosed": {
+      "type": "object",
+      "description": "A PR was closed (merged or closed without merging).",
+      "required": ["type", "pr_number", "title", "branch"],
+      "properties": {
+        "type": { "const": "PrClosed" },
+        "pr_number": { "type": "integer", "format": "int64", "minimum": 0 },
+        "title": { "type": "string" },
+        "branch": { "type": "string" }
+      }
+    },
+    "GitStateChanged": {
+      "type": "object",
+      "description": "Git state (branches, HEAD, commit graph) changed for a repository. Subscribers refetch `/api/git/*` to stay in sync.",
+      "required": ["type", "repo"],
+      "properties": {
+        "type": { "const": "GitStateChanged" },
+        "repo": { "type": "string" }
+      }
+    },
+    "GuardrailExceeded": {
+      "type": "object",
+      "description": "A guardrail limit was exceeded (CI retries, review loops, or consecutive failures).",
+      "required": ["type", "guardrail", "branch", "pr_number", "count", "limit"],
+      "properties": {
+        "type": { "const": "GuardrailExceeded" },
+        "guardrail": { "$ref": "#/$defs/GuardrailKind" },
+        "branch": { "type": "string" },
+        "pr_number": {
+          "type": ["integer", "null"],
+          "format": "int64",
+          "minimum": 0
+        },
+        "count": { "type": "integer", "format": "int64", "minimum": 0 },
+        "limit": { "type": "integer", "format": "int64", "minimum": 0 }
+      }
+    },
+    "AgentTargetChanged": {
+      "type": "object",
+      "description": "An agent's tmux target changed due to pane renumbering (PID-based reconciliation).",
+      "required": ["type", "old_target", "new_target", "pid"],
+      "properties": {
+        "type": { "const": "AgentTargetChanged" },
+        "old_target": { "type": "string" },
+        "new_target": { "type": "string" },
+        "pid": { "type": "integer", "format": "int32", "minimum": 0 }
+      }
+    },
+    "ActionPerformed": {
+      "type": "object",
+      "description": "A side-effect API action was performed. Consumed by the orchestrator notifier.",
+      "required": ["type", "origin", "action", "summary"],
+      "properties": {
+        "type": { "const": "ActionPerformed" },
+        "origin": { "$ref": "#/$defs/ActionOrigin" },
+        "action": {
+          "type": "string",
+          "description": "API action name (e.g. \"dispatch_issue\", \"kill_agent\", \"merge_pr\")."
+        },
+        "summary": { "type": "string" }
+      }
+    },
+    "DispatchRejected": {
+      "type": "object",
+      "description": "A dispatch request was rejected by the contract-layer gatekeeper before an agent was spawned. This event is the **only** signal subscribers receive for rejected intents — no `AgentAppeared` / `AgentStatusChanged` fires for them.",
+      "required": ["type", "intent_summary", "origin", "error"],
+      "properties": {
+        "type": { "const": "DispatchRejected" },
+        "intent_summary": { "$ref": "#/$defs/DispatchIntentSummary" },
+        "origin": { "$ref": "#/$defs/ActionOrigin" },
+        "error": { "$ref": "#/$defs/TmaiError" }
+      }
+    },
+    "VendorAvailabilityChanged": {
+      "type": "object",
+      "description": "Vendor availability transitioned (rate-limit hit or cleared, outage started or resolved).",
+      "required": ["type", "vendor", "old", "new", "detected_via"],
+      "properties": {
+        "type": { "const": "VendorAvailabilityChanged" },
+        "vendor": { "type": "string", "description": "Vendor identifier (e.g. \"anthropic\", \"openai\", \"google\")." },
+        "account": {
+          "type": "string",
+          "description": "Account label, when the deployment distinguishes accounts."
+        },
+        "old": { "$ref": "#/$defs/VendorAvailabilityState" },
+        "new": { "$ref": "#/$defs/VendorAvailabilityState" },
+        "detected_via": { "$ref": "#/$defs/DetectionSource" }
+      }
+    },
+    "CapacityChanged": {
+      "type": "object",
+      "description": "The global capacity counter moved (slot consumed or freed) or the configured limit was adjusted. `delta` is the signed change applied by this event (+1 spawn, -1 terminal, 0 on `limit_changed` / `reconciled`).",
+      "required": ["type", "current", "limit", "delta", "cause"],
+      "properties": {
+        "type": { "const": "CapacityChanged" },
+        "current": { "type": "integer", "format": "int64", "minimum": 0 },
+        "limit": { "type": "integer", "format": "int64", "minimum": 0 },
+        "delta": { "type": "integer", "format": "int32" },
+        "cause": { "$ref": "#/$defs/CapacityCauseSummary" }
+      }
+    },
+    "ContractViolation": {
+      "type": "object",
+      "description": "A contract-layer invariant was violated (auth failure, schema mismatch, unauthorized operation). Distinct from `DispatchRejected`, which is gatekeeper-specific.",
+      "required": ["type", "origin", "code"],
+      "properties": {
+        "type": { "const": "ContractViolation" },
+        "origin": { "$ref": "#/$defs/ActionOrigin" },
+        "code": { "$ref": "#/$defs/ErrorCode" },
+        "context": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Code-specific structured context. Omitted from the wire when the emitter attached nothing."
+        }
+      }
+    },
+    "DispatchBypassUsed": {
+      "type": "object",
+      "description": "A bypass flag was used for a dispatch, skipping one or more contract-layer checks. Always audit-logged.",
+      "required": ["type", "origin", "bypassed", "reason"],
+      "properties": {
+        "type": { "const": "DispatchBypassUsed" },
+        "origin": { "$ref": "#/$defs/ActionOrigin" },
+        "bypassed": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Names of the bypassed checks / stages (e.g. \"capacity_check\", \"vendor_availability\")."
+        },
+        "reason": { "type": "string" }
+      }
+    },
+    "BundleStatusChanged": {
+      "type": "object",
+      "description": "Bundle rollup status transitioned. Emits only on bundle-level changes — sub-dispatch transitions still surface as `AgentStatusChanged`.",
+      "required": ["type", "bundle_id", "old", "new"],
+      "properties": {
+        "type": { "const": "BundleStatusChanged" },
+        "bundle_id": { "$ref": "#/$defs/BundleId" },
+        "old": { "$ref": "#/$defs/BundleStatus" },
+        "new": { "$ref": "#/$defs/BundleStatus" }
+      }
+    }
+  }
+}

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,121 @@
+# tmai error taxonomy
+
+> **Taxonomy version:** `1` · See `openapi.json` → `components.schemas.TmaiError` for the machine-readable shape.
+
+Every failure that crosses a tmai contract boundary — MCP tool call, WebUI REST response, CLI invocation, or internal facade API — is expressed as a **`TmaiError`**. Callers switch on the stable `code` field instead of parsing free-form `message` text.
+
+## Payload shape
+
+```json
+{
+  "code": "CapacityExceeded",
+  "message": "max dispatchable agents reached (8/8)",
+  "retry_hint": { "kind": "backoff_ms", "ms": 2000 },
+  "context": { "current": 8, "limit": 8 },
+  "trace_id": "req-2f9a…"
+}
+```
+
+| Field        | Type                        | Required | Meaning |
+|--------------|-----------------------------|----------|---------|
+| `code`       | [`ErrorCode`](#errorcode)   | yes      | Machine-readable, stable classification |
+| `message`    | string                      | yes      | Human-readable summary (English v1) |
+| `retry_hint` | [`RetryHint`](#retryhint)   | no       | Advisory retry guidance; absent when not retryable by design |
+| `context`    | object                      | no       | Code-specific structured detail |
+| `trace_id`   | string                      | no       | Correlation id threaded through MCP / WebUI / `tracing` spans |
+
+`context` and `retry_hint` are **omitted from the wire** when the emitter attached nothing (`null` / `None`). UI clients MUST tolerate their absence.
+
+## Surfaces
+
+| Surface | How the error appears |
+|---------|-----------------------|
+| **MCP** | Tool error with structured payload (MCP's tool-error-with-data convention) |
+| **WebUI REST** | JSON body on `4xx` / `5xx`; toast uses `code` + `message`, details panel shows `context` |
+| **CLI** | Non-zero exit; single-line JSON printed to stderr, parseable by callers |
+| **Internal** | `Result<T, TmaiError>` at every contract boundary — `anyhow::Error` never leaks out |
+
+## Versioning
+
+- `code` values are **stable forever once added**. Deprecations get serde aliases; removals never happen.
+- Adding a new `code` is a **minor-version bump** of the taxonomy. The current version is `1` and is exposed at `GET /api/version` and in MCP server info.
+- UI clients MUST treat unknown `code` values as `Internal` and surface the `message` — forward compatibility rule.
+
+## `ErrorCode`
+
+Codes are grouped into four buckets. Within each bucket, callers reason about whole categories (e.g., "should I retry capacity-class errors?") rather than matching individual variants.
+
+### Capacity & availability
+
+| Code | When it fires | Typical `context` | Typical `retry_hint` |
+|------|---------------|-------------------|-----------------------|
+| `CapacityExceeded` | Global dispatch-slot ceiling reached (max dispatchable agents, queue depth against a hard cap) | `{ current, limit }` | `BackoffMs` |
+| `VendorUnavailable` | Downstream vendor rate-limited or in outage; retry is gated on vendor recovery | `{ vendor, account?, reason? }` | `RetryAfter` when `resume_at` known, else `BackoffMs` |
+| `QueueFull` | A bounded queue (e.g. dispatch queue) rejected enqueue | `{ queue, depth, capacity }` | `BackoffMs` |
+
+### State & lifecycle
+
+| Code | When it fires | Typical `context` | Typical `retry_hint` |
+|------|---------------|-------------------|-----------------------|
+| `AgentNotFound` | Target does not resolve to a live or remembered agent | `{ target }` | `NotRetryable` |
+| `AgentInTerminalState` | Agent exists but has exited / been killed; the requested operation is no longer valid | `{ target, state }` | `NotRetryable` |
+| `WorktreeConflict` | Worktree operation conflicts with current filesystem / agent state (name taken, dirty tree, still-running agent) | `{ path?, branch?, reason }` | `NotRetryable` |
+
+### Permissions & auth
+
+| Code | When it fires | Typical `context` | Typical `retry_hint` |
+|------|---------------|-------------------|-----------------------|
+| `PermissionDenied` | Caller is authenticated but not authorized for the operation | `{ operation, required }` | `NotRetryable` |
+| `TokenInvalid` | Credential / token missing, expired, or malformed | `{ reason }` (never the token itself) | `NotRetryable` |
+
+### Input / request
+
+| Code | When it fires | Typical `context` | Typical `retry_hint` |
+|------|---------------|-------------------|-----------------------|
+| `InvalidArgument` | A request argument failed validation (out-of-range, malformed) | `{ field, received?, expected? }` | `NotRetryable` |
+| `SchemaMismatch` | Request body or MCP tool-input schema did not match the expected shape | `{ pointer, expected, received }` | `NotRetryable` |
+
+### Downstream
+
+| Code | When it fires | Typical `context` | Typical `retry_hint` |
+|------|---------------|-------------------|-----------------------|
+| `VendorError` | Vendor returned an error that is **not** a rate-limit / outage; the raw vendor response is preserved in `context.vendor_error` | `{ vendor, vendor_error }` | caller-dependent |
+| `TmuxError` | A tmux command failed (spawn, `new-window`, `send-keys`) | `{ operation, reason }` | `BackoffMs` often applicable |
+| `IpcError` | IPC channel (PTY / socket) disconnected or errored | `{ endpoint?, reason }` | `BackoffMs` |
+
+### Internal
+
+| Code | When it fires | Typical `context` | Typical `retry_hint` |
+|------|---------------|-------------------|-----------------------|
+| `Internal` | Fallback for unexpected failures. New call sites MUST prefer a more specific code when one exists | varies | varies |
+
+## `RetryHint`
+
+Internally tagged on `kind`.
+
+```json
+{ "kind": "retry_after", "resume_at": "2026-04-18T12:34:56Z" }
+{ "kind": "backoff_ms",  "ms": 2000 }
+{ "kind": "not_retryable" }
+```
+
+- `retry_after` — used when the underlying resource advertises a wall-clock reset (typical for vendor rate limits).
+- `backoff_ms` — caller-driven clock; appropriate for transient capacity / IPC conditions.
+- `not_retryable` — the caller should surface the failure; retrying will not change the outcome without external action.
+
+Retry orchestration is explicitly **out of scope** for the taxonomy itself — `retry_hint` is advisory.
+
+## Non-goals for the taxonomy
+
+- **Localization** — v1 is English; the shape supports future i18n.
+- **Warning / notice channel** — non-fatal conditions (e.g. auto-resume scheduled) are emitted as [`CoreEvent`](./corevents.schema.json) variants, not as `TmaiError`.
+- **Full internal-error migration** — existing `anyhow::Error` paths migrate incrementally as each boundary is touched.
+
+## Emitting a new code
+
+1. Add the variant to `ErrorCode` in `openapi.json` → `components.schemas.ErrorCode.enum`.
+2. Document its firing condition, typical `context`, and typical `retry_hint` in this file.
+3. Bump `x-taxonomy-version` on `ErrorCode` **by one**.
+4. Call out the new code in the release notes — callers may want to add handling.
+
+Removing or renaming a code is **never** allowed; deprecations are handled by keeping the code and annotating its documentation.

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,11 +7,41 @@
   <meta name="description" content="Public API contracts for tmai-core">
   <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64,">
   <style>
-    body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    html, body { margin: 0; padding: 0; height: 100%; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    body { display: flex; flex-direction: column; }
+    nav.spec-bar {
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      gap: 1.25rem;
+      padding: 0.55rem 1rem;
+      background: #0b1020;
+      color: #e6ecff;
+      border-bottom: 1px solid #1b2340;
+      font-size: 13px;
+    }
+    nav.spec-bar .brand { font-weight: 600; letter-spacing: 0.02em; }
+    nav.spec-bar a { color: #8ab4ff; text-decoration: none; }
+    nav.spec-bar a:hover { text-decoration: underline; }
+    nav.spec-bar .sep { color: #445; }
+    main.spec-body { flex: 1 1 auto; min-height: 0; }
+    redoc { display: block; height: 100%; }
   </style>
 </head>
 <body>
-  <redoc spec-url="openapi.json"></redoc>
+  <nav class="spec-bar" aria-label="tmai spec navigation">
+    <span class="brand">tmai-api-spec</span>
+    <span class="sep">·</span>
+    <a href="./index.html">REST API (Redoc)</a>
+    <a href="./openapi.json">openapi.json</a>
+    <a href="./corevents.schema.json">corevents.schema.json</a>
+    <a href="./errors.md">errors.md</a>
+    <span class="sep">·</span>
+    <a href="https://github.com/trust-delta/tmai-api-spec" rel="noopener">GitHub</a>
+  </nav>
+  <main class="spec-body">
+    <redoc spec-url="openapi.json"></redoc>
+  </main>
   <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 </body>
 </html>

--- a/openapi.json
+++ b/openapi.json
@@ -12,6 +12,19 @@
     },
     "version": "1.7.0"
   },
+  "servers": [
+    {
+      "url": "http://localhost:{port}",
+      "description": "Local tmai-core server. Each user runs their own instance; there is no hosted deployment.",
+      "variables": {
+        "port": {
+          "default": "8080",
+          "description": "Port the user's tmai-core instance is listening on (configured via tmai-core settings)."
+        }
+      }
+    }
+  ],
+  "security": [],
   "paths": {
     "/api/task-meta": {
       "get": {
@@ -34,6 +47,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "description": "Request failed at a tmai contract boundary. The body is a structured `TmaiError` — callers switch on `code` rather than parsing `message`.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Unexpected internal failure. Body is a `TmaiError` with `code: \"Internal\"` unless a more specific downstream code applies.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
           }
         }
       }
@@ -41,6 +70,103 @@
   },
   "components": {
     "schemas": {
+      "ErrorCode": {
+        "type": "string",
+        "description": "Machine-readable, stable error classification.\n\nValues are **stable forever once added** — deprecations are handled by aliasing, not removal. Adding a new code is a minor-version bump of the taxonomy. See `docs/errors.md` for each code's meaning and usage.",
+        "enum": [
+          "CapacityExceeded",
+          "VendorUnavailable",
+          "QueueFull",
+          "AgentNotFound",
+          "AgentInTerminalState",
+          "WorktreeConflict",
+          "PermissionDenied",
+          "TokenInvalid",
+          "InvalidArgument",
+          "SchemaMismatch",
+          "VendorError",
+          "TmuxError",
+          "IpcError",
+          "Internal"
+        ],
+        "x-taxonomy-version": "1"
+      },
+      "RetryHint": {
+        "description": "Advisory retry guidance. Informational only — the caller decides whether to act on it.",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "RetryAfter",
+            "description": "Retry after a specific wall-clock instant (RFC3339).",
+            "required": ["kind", "resume_at"],
+            "properties": {
+              "kind": { "type": "string", "const": "retry_after" },
+              "resume_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "ISO-8601 / RFC3339 timestamp at which the caller may retry."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "BackoffMs",
+            "description": "Retry after a millisecond backoff (caller-driven clock).",
+            "required": ["kind", "ms"],
+            "properties": {
+              "kind": { "type": "string", "const": "backoff_ms" },
+              "ms": {
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0,
+                "description": "Milliseconds to wait before retrying."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "NotRetryable",
+            "description": "The failure is not retryable; the caller should surface it instead.",
+            "required": ["kind"],
+            "properties": {
+              "kind": { "type": "string", "const": "not_retryable" }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "retry_after": "#/components/schemas/RetryHint",
+            "backoff_ms": "#/components/schemas/RetryHint",
+            "not_retryable": "#/components/schemas/RetryHint"
+          }
+        }
+      },
+      "TmaiError": {
+        "type": "object",
+        "description": "Structured error carried across every tmai contract boundary (MCP, WebUI, CLI, internal facade API). `code` is the primary dispatch key; `message` is human-readable; `retry_hint` is advisory; `context` is per-code structured detail; `trace_id` ties the error to a tracing span for cross-surface correlation.\n\nSee `docs/errors.md` for code-by-code documentation.",
+        "required": ["code", "message"],
+        "properties": {
+          "code": { "$ref": "#/components/schemas/ErrorCode" },
+          "message": {
+            "type": "string",
+            "description": "Human-readable summary. English-only in v1 (shape supports future i18n)."
+          },
+          "retry_hint": {
+            "$ref": "#/components/schemas/RetryHint",
+            "description": "Advisory retry guidance; absent when the caller has no way to retry."
+          },
+          "context": {
+            "description": "Code-specific structured detail. Always an object in practice; the field is omitted from the wire when the emitter attached nothing.",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "trace_id": {
+            "type": "string",
+            "description": "Request/span identifier for correlating this error across MCP, WebUI, and internal tracing spans."
+          }
+        }
+      },
       "Milestone": {
         "type": "object",
         "description": "A single milestone event in the task lifecycle.\n\nPart of the type-sharing PoC (#446): generated TypeScript lives in\n`crates/tmai-app/web/src/types/generated/Milestone.ts`.",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "tmai-api-spec",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Public API contracts for tmai (openapi.json, corevents.schema.json, error taxonomy).",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "lint:openapi": "redocly lint openapi.json",
+    "test:schemas": "node tests/validate.mjs",
+    "test": "npm run lint:openapi && npm run test:schemas"
+  },
+  "devDependencies": {
+    "@redocly/cli": "^1.27.0",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
+  }
+}

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,7 @@
+extends:
+  - recommended
+
+rules:
+  # tmai-core is a user-local service (no hosted deployment). `localhost` is
+  # the canonical server URL, not a placeholder.
+  no-server-example.com: off

--- a/tests/fixtures/corevents/invalid/capacity-changed-missing-delta.json
+++ b/tests/fixtures/corevents/invalid/capacity-changed-missing-delta.json
@@ -1,0 +1,6 @@
+{
+  "type": "CapacityChanged",
+  "current": 4,
+  "limit": 8,
+  "cause": { "kind": "agent_spawned", "target": "main:0.3" }
+}

--- a/tests/fixtures/corevents/invalid/unknown-type.json
+++ b/tests/fixtures/corevents/invalid/unknown-type.json
@@ -1,0 +1,1 @@
+{ "type": "ThisEventDoesNotExist", "foo": "bar" }

--- a/tests/fixtures/corevents/invalid/vendor-availability-bad-state.json
+++ b/tests/fixtures/corevents/invalid/vendor-availability-bad-state.json
@@ -1,0 +1,7 @@
+{
+  "type": "VendorAvailabilityChanged",
+  "vendor": "anthropic",
+  "old": { "state": "typo_state" },
+  "new": { "state": "available" },
+  "detected_via": "HttpHook"
+}

--- a/tests/fixtures/corevents/valid/agent-stopped-null-message.json
+++ b/tests/fixtures/corevents/valid/agent-stopped-null-message.json
@@ -1,0 +1,6 @@
+{
+  "type": "AgentStopped",
+  "target": "main:0.1",
+  "cwd": "/home/user/project",
+  "last_assistant_message": null
+}

--- a/tests/fixtures/corevents/valid/agents-updated.json
+++ b/tests/fixtures/corevents/valid/agents-updated.json
@@ -1,0 +1,1 @@
+{ "type": "AgentsUpdated" }

--- a/tests/fixtures/corevents/valid/bundle-status-changed.json
+++ b/tests/fixtures/corevents/valid/bundle-status-changed.json
@@ -1,0 +1,6 @@
+{
+  "type": "BundleStatusChanged",
+  "bundle_id": "bundle-multirepo-7",
+  "old": "running",
+  "new": "partially_completed"
+}

--- a/tests/fixtures/corevents/valid/capacity-changed.json
+++ b/tests/fixtures/corevents/valid/capacity-changed.json
@@ -1,0 +1,7 @@
+{
+  "type": "CapacityChanged",
+  "current": 4,
+  "limit": 8,
+  "delta": 1,
+  "cause": { "kind": "agent_spawned", "target": "main:0.3" }
+}

--- a/tests/fixtures/corevents/valid/contract-violation.json
+++ b/tests/fixtures/corevents/valid/contract-violation.json
@@ -1,0 +1,6 @@
+{
+  "type": "ContractViolation",
+  "origin": { "kind": "Agent", "id": "main:0.0", "is_orchestrator": true },
+  "code": "SchemaMismatch",
+  "context": { "field": "role", "expected": "implementer" }
+}

--- a/tests/fixtures/corevents/valid/dispatch-bypass-used.json
+++ b/tests/fixtures/corevents/valid/dispatch-bypass-used.json
@@ -1,0 +1,6 @@
+{
+  "type": "DispatchBypassUsed",
+  "origin": { "kind": "Human", "interface": "cli" },
+  "bypassed": ["capacity_check", "vendor_availability"],
+  "reason": "manual override during incident"
+}

--- a/tests/fixtures/corevents/valid/dispatch-rejected.json
+++ b/tests/fixtures/corevents/valid/dispatch-rejected.json
@@ -1,0 +1,17 @@
+{
+  "type": "DispatchRejected",
+  "intent_summary": {
+    "project_path": "/repos/foo",
+    "role": "implementer",
+    "bundle_id": "bundle-42",
+    "prompt_hash": "abc123",
+    "issue_number": 463
+  },
+  "origin": { "kind": "Human", "interface": "webui" },
+  "error": {
+    "code": "CapacityExceeded",
+    "message": "max dispatchable agents reached (8/8)",
+    "retry_hint": { "kind": "backoff_ms", "ms": 2000 },
+    "context": { "current": 8, "limit": 8 }
+  }
+}

--- a/tests/fixtures/corevents/valid/pr-review-feedback.json
+++ b/tests/fixtures/corevents/valid/pr-review-feedback.json
@@ -1,0 +1,7 @@
+{
+  "type": "PrReviewFeedback",
+  "pr_number": 123,
+  "title": "feat: add contract layer",
+  "comments_summary": "please add tests",
+  "review_count": 2
+}

--- a/tests/fixtures/corevents/valid/vendor-availability-changed.json
+++ b/tests/fixtures/corevents/valid/vendor-availability-changed.json
@@ -1,0 +1,8 @@
+{
+  "type": "VendorAvailabilityChanged",
+  "vendor": "anthropic",
+  "account": "team-main",
+  "old": { "state": "available" },
+  "new": { "state": "rate_limited", "resume_at": "2026-04-18T12:34:56Z" },
+  "detected_via": "HttpHook"
+}

--- a/tests/fixtures/tmai-error/invalid/bad-retry-hint.json
+++ b/tests/fixtures/tmai-error/invalid/bad-retry-hint.json
@@ -1,0 +1,5 @@
+{
+  "code": "CapacityExceeded",
+  "message": "oops",
+  "retry_hint": { "kind": "bogus_kind" }
+}

--- a/tests/fixtures/tmai-error/invalid/missing-message.json
+++ b/tests/fixtures/tmai-error/invalid/missing-message.json
@@ -1,0 +1,3 @@
+{
+  "code": "Internal"
+}

--- a/tests/fixtures/tmai-error/invalid/unknown-code.json
+++ b/tests/fixtures/tmai-error/invalid/unknown-code.json
@@ -1,0 +1,4 @@
+{
+  "code": "SomethingMadeUp",
+  "message": "does not exist"
+}

--- a/tests/fixtures/tmai-error/valid/agent-not-found.json
+++ b/tests/fixtures/tmai-error/valid/agent-not-found.json
@@ -1,0 +1,6 @@
+{
+  "code": "AgentNotFound",
+  "message": "agent not found: main:0.0",
+  "retry_hint": { "kind": "not_retryable" },
+  "context": { "target": "main:0.0" }
+}

--- a/tests/fixtures/tmai-error/valid/capacity-exceeded.json
+++ b/tests/fixtures/tmai-error/valid/capacity-exceeded.json
@@ -1,0 +1,7 @@
+{
+  "code": "CapacityExceeded",
+  "message": "max dispatchable agents reached (8/8)",
+  "retry_hint": { "kind": "backoff_ms", "ms": 2000 },
+  "context": { "current": 8, "limit": 8 },
+  "trace_id": "req-2f9a"
+}

--- a/tests/fixtures/tmai-error/valid/ipc-minimal.json
+++ b/tests/fixtures/tmai-error/valid/ipc-minimal.json
@@ -1,0 +1,4 @@
+{
+  "code": "IpcError",
+  "message": "ipc channel disconnected"
+}

--- a/tests/fixtures/tmai-error/valid/vendor-unavailable.json
+++ b/tests/fixtures/tmai-error/valid/vendor-unavailable.json
@@ -1,0 +1,6 @@
+{
+  "code": "VendorUnavailable",
+  "message": "anthropic rate-limited; retry after reset",
+  "retry_hint": { "kind": "retry_after", "resume_at": "2026-04-18T12:34:56Z" },
+  "context": { "vendor": "anthropic", "reason": "429" }
+}

--- a/tests/validate.mjs
+++ b/tests/validate.mjs
@@ -1,0 +1,98 @@
+// Validate corevents.schema.json and the OpenAPI TmaiError schema against the
+// fixture corpus in tests/fixtures/. Exits non-zero on the first mismatch so
+// CI catches contract drift between this repo, tmai-core, and UI consumers.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "..");
+
+const readJson = (rel) =>
+  JSON.parse(fs.readFileSync(path.join(repoRoot, rel), "utf8"));
+
+const listJson = (rel) => {
+  const dir = path.join(repoRoot, rel);
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => path.join(rel, f));
+};
+
+const openapi = readJson("openapi.json");
+const corevents = readJson("corevents.schema.json");
+
+// `strict: false` — OpenAPI 3.1 documents use vocabulary (`example`, `tags`,
+// `operationId`, `x-*`) that Ajv's strict mode rejects. We only care about
+// schema-shape validation, not OpenAPI linting (redocly handles that).
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+
+// Register openapi.json as a root schema so we can $ref into its subschemas.
+// Internal `#/components/schemas/X` references inside TmaiError resolve
+// against this root, as intended.
+ajv.addSchema(openapi, "openapi.json");
+
+const validateCoreEvent = ajv.compile(corevents);
+const validateTmaiError = ajv.compile({
+  $ref: "openapi.json#/components/schemas/TmaiError",
+});
+
+let failed = 0;
+
+const check = (label, ok, detail) => {
+  if (ok) {
+    console.log(`  ok   ${label}`);
+  } else {
+    failed += 1;
+    console.log(`  FAIL ${label}`);
+    if (detail) console.log(`       ${detail}`);
+  }
+};
+
+const runSuite = (name, validator, validDir, invalidDir) => {
+  console.log(`\n# ${name}`);
+  for (const rel of listJson(validDir)) {
+    const doc = readJson(rel);
+    const ok = validator(doc);
+    check(
+      `valid:   ${path.basename(rel)}`,
+      ok,
+      ok ? "" : ajv.errorsText(validator.errors),
+    );
+  }
+  for (const rel of listJson(invalidDir)) {
+    const doc = readJson(rel);
+    const ok = validator(doc);
+    // invalid fixtures MUST be rejected
+    check(
+      `invalid: ${path.basename(rel)}`,
+      !ok,
+      ok ? "fixture was accepted but should have been rejected" : "",
+    );
+  }
+};
+
+runSuite(
+  "CoreEvent (corevents.schema.json)",
+  validateCoreEvent,
+  "tests/fixtures/corevents/valid",
+  "tests/fixtures/corevents/invalid",
+);
+
+runSuite(
+  "TmaiError (openapi.json#/components/schemas/TmaiError)",
+  validateTmaiError,
+  "tests/fixtures/tmai-error/valid",
+  "tests/fixtures/tmai-error/invalid",
+);
+
+if (failed > 0) {
+  console.error(`\n${failed} fixture(s) failed validation`);
+  process.exit(1);
+} else {
+  console.log(`\nall fixtures validated successfully`);
+}


### PR DESCRIPTION
## Summary

Brings the public spec repo in step with the tmai-core (private) / tmai-api-spec (public) / tmai-react (public) split by publishing the two contract surfaces that every downstream client needs.

- **`TmaiError` / `ErrorCode` / `RetryHint` taxonomy** added to `openapi.json` and documented in `docs/errors.md`. `/api/task-meta` now references the schema on its `4XX` / `5XX` responses, giving callers one structured failure shape across MCP, WebUI REST, CLI, and internal facade surfaces.
- **`corevents.schema.json`** bootstrapped as a JSON Schema 2020-12 document covering every `CoreEvent` variant currently emitted by `tmai-core`, including the contract-layer additions (`DispatchRejected`, `VendorAvailabilityChanged`, `CapacityChanged`, `ContractViolation`, `DispatchBypassUsed`, `BundleStatusChanged`). `DispatchRejected` / `ContractViolation` reference the same `TmaiError` / `ErrorCode` shape to keep the two spec files in sync.
- **Validation tooling** — redocly lint + ajv-based fixture corpus (`tests/fixtures/corevents`, `tests/fixtures/tmai-error`, `tests/validate.mjs`) wired into a new `validate` workflow so contract drift between this repo, `tmai-core`, and UI consumers fails CI.
- **GitHub Pages** now publishes `corevents.schema.json` and `errors.md` alongside the Redoc viewer; `docs/index.html` grows a navigation bar linking the three public artefacts.

## Closes

- Closes #1
- Closes #2

## Test plan

- [x] `npm run lint:openapi` → clean (zero errors / warnings)
- [x] `npm run test:schemas` → 9 valid + 3 invalid CoreEvent fixtures, 4 valid + 3 invalid TmaiError fixtures, all match expectations
- [ ] CI `validate` workflow passes on the PR
- [ ] CI `Deploy to GitHub Pages` publishes the augmented `_site/` on merge (manual verification post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * API仕様書とスキーマファイルを追加
  * エラーハンドリングの分類法を定義

* **Documentation**
  * READMEをアーキテクチャ説明で更新
  * エラー分類法の詳細ガイドを追加
  * ドキュメント ナビゲーションを改善

* **Tests**
  * 検証スクリプトと複数のテストフィクスチャを追加

* **Chores**
  * GitHub Actionsワークフローを設定
  * プロジェクト設定ファイルを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->