### PR TITLE
feat: QueuedPrompt schema + /agents/{id}/prompt-queue GET/DELETE + PromptQueueChanged SSE (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,20 @@ UI clients can choose any subset of these channels. The standard UIs `tmai-ratat
 
 Hosted at https://trust-delta.github.io/tmai-api-spec/ (Redoc-rendered).
 
+## Changelog
+
+### v1.8.0 (additive — minor bump)
+
+- **`QueuedPrompt` schema** added to `openapi.json` → `components.schemas`. References existing `ActionOrigin`.
+- **`GET /agents/{id}/prompt-queue`** — enumerate the FIFO queue for an agent (oldest-first). Returns `404` only when the agent itself is unknown.
+- **`DELETE /agents/{id}/prompt-queue/{prompt_id}`** — cancel a single queued prompt. Returns `200 { status: "cancelled" | "already_drained" }`. Deleting an unknown `prompt_id` under a **known** agent returns `already_drained` (idempotent); `404` is reserved for unknown agents. Servers MUST NOT 500 on unknown prompt IDs.
+- **`PromptQueueChanged` SSE variant** added to `corevents.schema.json`. Emitted on enqueue, drain, and cancel; carries the full updated queue. Consumers SHOULD tolerate this variant silently if they do not yet consume it (forward-compatibility rule).
+
+### v0.1.0 — contract-layer bootstrap
+
 ## Status
 
-**v0.1.0 — contract-layer bootstrap.** The initial PoC endpoint (`GET /api/task-meta`, migrated from `tmai-core` issue #446) now sits alongside the full `TmaiError` / `ErrorCode` / `RetryHint` taxonomy (issue #2) and `corevents.schema.json` covering every `CoreEvent` variant including the contract-layer additions (issue #1). The remaining ~79 REST endpoints will be added incrementally; breaking changes are permitted at any time during v0.x.
+**v1.8.0.** The initial PoC endpoint (`GET /api/task-meta`, migrated from `tmai-core` issue #446) now sits alongside the full `TmaiError` / `ErrorCode` / `RetryHint` taxonomy (issue #2), `corevents.schema.json` covering every `CoreEvent` variant including the contract-layer additions (issue #1), and the prompt-queue contract (`QueuedPrompt`, `GET`/`DELETE /agents/{id}/prompt-queue`, `PromptQueueChanged` SSE — issue #5). The remaining ~79 REST endpoints will be added incrementally; breaking changes are permitted at any time during v0.x.
 
 ## License
 

--- a/corevents.schema.json
+++ b/corevents.schema.json
@@ -40,7 +40,8 @@
     { "$ref": "#/$defs/CapacityChanged" },
     { "$ref": "#/$defs/ContractViolation" },
     { "$ref": "#/$defs/DispatchBypassUsed" },
-    { "$ref": "#/$defs/BundleStatusChanged" }
+    { "$ref": "#/$defs/BundleStatusChanged" },
+    { "$ref": "#/$defs/PromptQueueChanged" }
   ],
   "$defs": {
     "ActionOrigin": {
@@ -672,6 +673,47 @@
         "bundle_id": { "$ref": "#/$defs/BundleId" },
         "old": { "$ref": "#/$defs/BundleStatus" },
         "new": { "$ref": "#/$defs/BundleStatus" }
+      }
+    },
+    "QueuedPrompt": {
+      "type": "object",
+      "description": "A single prompt waiting in an agent's send-queue. Prompts are delivered in FIFO order when the target agent transitions to Idle.",
+      "required": ["id", "prompt", "queued_at"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Server-assigned stable identifier (uuid v7 recommended for monotonic ordering)."
+        },
+        "prompt": {
+          "type": "string",
+          "description": "Prompt text that will be delivered when the target agent becomes Idle."
+        },
+        "queued_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp when the prompt was enqueued."
+        },
+        "origin": {
+          "$ref": "#/$defs/ActionOrigin",
+          "description": "Optional caller origin (human/agent/system) captured at enqueue time."
+        }
+      }
+    },
+    "PromptQueueChanged": {
+      "type": "object",
+      "description": "The prompt queue for an agent changed (prompt enqueued, drained on delivery, or cancelled via DELETE). Carries the full updated queue so consumers can replace their local snapshot without diffing.\n\nThis variant MUST be ignored by clients that do not yet consume it — it follows the forward-compatibility rules for unknown variants. tmai-react v1 uses 3 s polling; SSE adoption is a planned follow-up.",
+      "required": ["type", "target", "queue"],
+      "properties": {
+        "type": { "const": "PromptQueueChanged" },
+        "target": {
+          "type": "string",
+          "description": "Agent target ID whose queue changed (e.g. \"main:0.0\")."
+        },
+        "queue": {
+          "type": "array",
+          "description": "Full updated queue, ordered oldest-first (delivery order). Empty array means the queue is now empty.",
+          "items": { "$ref": "#/$defs/QueuedPrompt" }
+        }
       }
     }
   }

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "1.7.0"
+    "version": "1.8.0"
   },
   "servers": [
     {
@@ -26,6 +26,127 @@
   ],
   "security": [],
   "paths": {
+    "/agents/{id}/prompt-queue": {
+      "get": {
+        "tags": ["prompt-queue"],
+        "summary": "List queued prompts for an agent",
+        "description": "Returns all prompts currently waiting for the target agent, ordered oldest-first (delivery order). Returns an empty array when the queue is empty.",
+        "operationId": "list_prompt_queue",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Agent target ID (e.g. `main:0.0`).",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Queued prompts, ordered oldest-first (delivery order).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/QueuedPrompt" }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The agent itself is unknown. Callers MUST re-sync their agent list on this response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Request failed at a tmai contract boundary.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Unexpected internal failure.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{id}/prompt-queue/{prompt_id}": {
+      "delete": {
+        "tags": ["prompt-queue"],
+        "summary": "Cancel a queued prompt",
+        "description": "Cancels a single queued prompt by ID.\n\n**Idempotency contract**: deleting an unknown `prompt_id` under a *known* agent returns `200 { status: \"already_drained\" }`, not 404. Clients MUST treat `already_drained` as success — the optimistic cancel already matches reality, and the prompt may have been drained between the GET and this DELETE. Servers MUST NOT return 500 for unknown prompt IDs.\n\nThe 404 response is reserved exclusively for cases where the agent itself is unknown.",
+        "operationId": "cancel_queued_prompt",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Agent target ID (e.g. `main:0.0`).",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prompt_id",
+            "in": "path",
+            "required": true,
+            "description": "Stable identifier of the queued prompt to cancel.",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`cancelled` when the prompt was removed from the queue; `already_drained` when the prompt ID was not found under a known agent (idempotent — treat as success).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["status"],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": ["cancelled", "already_drained"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The agent itself is unknown. Callers MUST re-sync their agent list on this response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Request failed at a tmai contract boundary.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Unexpected internal failure.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/task-meta": {
       "get": {
         "tags": [
@@ -70,6 +191,77 @@
   },
   "components": {
     "schemas": {
+      "ActionOrigin": {
+        "description": "Who initiated an action — attached to events and queue entries that audit-matter or need per-origin handling.",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Human",
+            "required": ["kind", "interface"],
+            "properties": {
+              "kind": { "type": "string", "const": "Human" },
+              "interface": {
+                "type": "string",
+                "description": "Which UI: \"webui\", \"tui\", \"mobile\", \"cli\", etc."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "Agent",
+            "required": ["kind", "id", "is_orchestrator"],
+            "properties": {
+              "kind": { "type": "string", "const": "Agent" },
+              "id": { "type": "string", "description": "Agent target id (e.g. \"main:0.0\")." },
+              "is_orchestrator": { "type": "boolean" }
+            }
+          },
+          {
+            "type": "object",
+            "title": "System",
+            "required": ["kind", "subsystem"],
+            "properties": {
+              "kind": { "type": "string", "const": "System" },
+              "subsystem": {
+                "type": "string",
+                "description": "Subsystem name (e.g. \"auto_cleanup\", \"pr_monitor\")."
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "Human": "#/components/schemas/ActionOrigin",
+            "Agent": "#/components/schemas/ActionOrigin",
+            "System": "#/components/schemas/ActionOrigin"
+          }
+        }
+      },
+      "QueuedPrompt": {
+        "type": "object",
+        "description": "A single prompt waiting in an agent's send-queue. Prompts are delivered in FIFO order when the target agent transitions to Idle.",
+        "required": ["id", "prompt", "queued_at"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Server-assigned stable identifier (uuid v7 recommended for monotonic ordering)."
+          },
+          "prompt": {
+            "type": "string",
+            "description": "Prompt text that will be delivered when the target agent becomes Idle."
+          },
+          "queued_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "RFC 3339 timestamp when the prompt was enqueued."
+          },
+          "origin": {
+            "$ref": "#/components/schemas/ActionOrigin",
+            "description": "Optional caller origin (human/agent/system) captured at enqueue time."
+          }
+        }
+      },
       "ErrorCode": {
         "type": "string",
         "description": "Machine-readable, stable error classification.\n\nValues are **stable forever once added** — deprecations are handled by aliasing, not removal. Adding a new code is a minor-version bump of the taxonomy. See `docs/errors.md` for each code's meaning and usage.",
@@ -265,6 +457,10 @@
     {
       "name": "task-meta",
       "description": "Project task metadata — merges git worktree info with `.task-meta/` JSON"
+    },
+    {
+      "name": "prompt-queue",
+      "description": "Per-agent send-prompt queue — enumerate and cancel queued prompts before delivery"
     }
   ]
 }

--- a/tests/fixtures/corevents/invalid/prompt-queue-changed-missing-queue.json
+++ b/tests/fixtures/corevents/invalid/prompt-queue-changed-missing-queue.json
@@ -1,0 +1,4 @@
+{
+  "type": "PromptQueueChanged",
+  "target": "main:0.0"
+}

--- a/tests/fixtures/corevents/valid/prompt-queue-changed-empty.json
+++ b/tests/fixtures/corevents/valid/prompt-queue-changed-empty.json
@@ -1,0 +1,5 @@
+{
+  "type": "PromptQueueChanged",
+  "target": "worker:1.0",
+  "queue": []
+}

--- a/tests/fixtures/corevents/valid/prompt-queue-changed.json
+++ b/tests/fixtures/corevents/valid/prompt-queue-changed.json
@@ -1,0 +1,17 @@
+{
+  "type": "PromptQueueChanged",
+  "target": "main:0.0",
+  "queue": [
+    {
+      "id": "01914b2e-7a1c-7000-8a2b-4f3c1d9e0b5a",
+      "prompt": "Run the full test suite and report results.",
+      "queued_at": "2026-04-20T10:00:00Z",
+      "origin": { "kind": "Human", "interface": "webui" }
+    },
+    {
+      "id": "01914b2e-9c4d-7000-a3e7-2b1f8d6c0e4f",
+      "prompt": "Summarize the changes made so far.",
+      "queued_at": "2026-04-20T10:01:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves #5. Adds the full prompt-queue contract surface required by tmai-react PR #12 and tmai-core implementation.

- **`QueuedPrompt` schema** added to `openapi.json` → `components.schemas` (with `ActionOrigin` also added as a first-class schema for the reference)
- **`GET /agents/{id}/prompt-queue`** — returns FIFO queue oldest-first; 404 only when agent is unknown
- **`DELETE /agents/{id}/prompt-queue/{prompt_id}`** — idempotent cancel: unknown `prompt_id` under a known agent → `200 { status: "already_drained" }`, not 404; 404 reserved for unknown agents
- **`PromptQueueChanged` SSE variant** added to `corevents.schema.json` — carries full updated queue on enqueue/drain/cancel
- semver bump `1.7.0` → `1.8.0` (additive minor)
- README changelog section added documenting consumer-facing semantics

## Test plan

- [x] `npm test` passes: Redocly lint clean + all schema fixtures validated (3 new CoreEvent fixtures added: 2 valid, 1 invalid)
- [x] Idempotency contract documented in `DELETE` endpoint description
- [x] Forward-compat note in `PromptQueueChanged` description (clients MUST ignore unknown variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロンプトキューの管理機能を追加。エージェント毎のキューの状態取得と個別プロンプトのキャンセルが可能に
  * キューの変更をリアルタイムで通知するイベントを追加
  * API バージョンを v1.8.0 にアップデート

<!-- end of auto-generated comment: release notes by coderabbit.ai -->